### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 > A streamlined Model Context Protocol (MCP) server for sending notifications via ntfy service (public or selfhosted with token support) 📲
 
+<a href="https://glama.ai/mcp/servers/@gitmotion/ntfy-me-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gitmotion/ntfy-me-mcp/badge" alt="ntfy-me-mcp MCP server" />
+</a>
 
 ## Overview
 


### PR DESCRIPTION
This PR adds a badge for the [ntfy-me-mcp](https://glama.ai/mcp/servers/@gitmotion/ntfy-me-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gitmotion/ntfy-me-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gitmotion/ntfy-me-mcp/badge" alt="ntfy-me-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.