### PR TITLE
bugfix: print/log to sys.stderr insted of sys.stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ async function initializeServer() {
   const transport = new StdioServerTransport();
   server
     .connect(transport)
-    .then(() => console.log("ntfy-me-mcp running on stdio"))
+    .then(() => console.error("ntfy-me-mcp running on stdio"))
     .catch((err) => console.error("Failed to start server:", err));
 }
 


### PR DESCRIPTION
Printing/logging sys.stdout causes initialization problems:

```
2025-08-04T17:31:34.484+02:00 DEBUG 43668 --- [mcp-tests] [pool-2-thread-1] io.modelcontextprotocol.spec.McpSchema   : Received JSON message: Topic 'MY_TOPIC' is marked as public. No authentication required.
2025-08-04T17:31:34.485+02:00 ERROR 43668 --- [mcp-tests] [pool-2-thread-1] i.m.c.transport.StdioClientTransport     : Error processing inbound message for line: Topic 'MY_TOPIC' is marked as public. No authentication required.

com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'Topic': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 6]
```